### PR TITLE
element_index shoudl be integer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "semaphore-merkle-tree",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2768,14 +2768,15 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
+      "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
       "dev": true,
       "optional": true,
       "requires": {
+        "bindings": "^1.5.0",
         "nan": "^2.12.1",
-        "node-pre-gyp": "^0.12.0"
+        "node-pre-gyp": "*"
       },
       "dependencies": {
         "abbrev": {
@@ -2823,7 +2824,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.1",
+          "version": "1.1.3",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2853,7 +2854,7 @@
           "optional": true
         },
         "debug": {
-          "version": "4.1.1",
+          "version": "3.2.6",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2880,12 +2881,12 @@
           "optional": true
         },
         "fs-minipass": {
-          "version": "1.2.5",
+          "version": "1.2.7",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
@@ -2911,7 +2912,7 @@
           }
         },
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.6",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2940,7 +2941,7 @@
           }
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2959,7 +2960,7 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -3001,7 +3002,7 @@
           "optional": true
         },
         "minipass": {
-          "version": "2.3.5",
+          "version": "2.9.0",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3011,12 +3012,12 @@
           }
         },
         "minizlib": {
-          "version": "1.2.1",
+          "version": "1.3.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.9.0"
           }
         },
         "mkdirp": {
@@ -3029,24 +3030,24 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
+          "version": "2.1.2",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "needle": {
-          "version": "2.3.0",
+          "version": "2.4.0",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^4.1.0",
+            "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.12.0",
+          "version": "0.14.0",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3060,7 +3061,7 @@
             "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
-            "tar": "^4"
+            "tar": "^4.4.2"
           }
         },
         "nopt": {
@@ -3074,13 +3075,22 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.6",
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "npm-normalize-package-bin": {
+          "version": "1.0.1",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.4.1",
+          "version": "1.4.7",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3151,7 +3161,7 @@
           "optional": true
         },
         "process-nextick-args": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -3192,7 +3202,7 @@
           }
         },
         "rimraf": {
-          "version": "2.6.3",
+          "version": "2.7.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3219,7 +3229,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.7.0",
+          "version": "5.7.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -3272,18 +3282,18 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.8",
+          "version": "4.4.13",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "yallist": "^3.0.3"
           }
         },
         "util-deprecate": {
@@ -3308,7 +3318,7 @@
           "optional": true
         },
         "yallist": {
-          "version": "3.0.3",
+          "version": "3.1.1",
           "bundled": true,
           "dev": true,
           "optional": true

--- a/ts/__tests__/MerkleTree.test.ts
+++ b/ts/__tests__/MerkleTree.test.ts
@@ -35,7 +35,7 @@ describe('tree test', function () {
     });
 
     it('tests empty get', async () => {
-        let {root, path_elements, path_index} = await tree.path(2);
+        let { root, path_elements, path_index } = await tree.path(2);
         const calculated_root = hasher.hash(1,
             path_elements[1],
             hasher.hash(0, default_value, path_elements[0]),
@@ -46,7 +46,7 @@ describe('tree test', function () {
     it('tests insert', async () => {
         await tree.update(0, '5');
         rollback_root = (await tree.path(0)).root;
-        let {root, path_elements, path_index} = await tree.path(0);
+        let { root, path_elements, path_index } = await tree.path(0);
         const calculated_root = hasher.hash(1,
             hasher.hash(0, '5', path_elements[0]),
             path_elements[1],
@@ -59,7 +59,7 @@ describe('tree test', function () {
         await tree.update(2, '9');
         await tree.update(2, '8');
         await tree.update(2, '82');
-        let {root, path_elements, path_index} = await tree.path(0);
+        let { root, path_elements, path_index } = await tree.path(0);
         const calculated_root = hasher.hash(1,
             hasher.hash(0, '5', path_elements[0]),
             path_elements[1],
@@ -70,6 +70,23 @@ describe('tree test', function () {
             path_elements[1],
         );
         assert.notEqual(root, wrong_calculated_root);
+    });
+
+    it('tests if path consistent', async () => {
+        await tree.update(1, '6');
+        await tree.update(2, '9');
+        await tree.update(3, '8');
+        await tree.update(4, '82');
+
+        const p1 = await tree.path(2);
+
+        const index = await tree.element_index('9')
+        const p2 = await tree.path(index)
+
+        assert.strictEqual(index, 2)
+        assert.equal(typeof (index), "number")
+        assert.equal(p1.path_elements.toString(), p2.path_elements.toString());
+
     });
 
     it('tests update log', async () => {

--- a/ts/__tests__/MerkleTree.test.ts
+++ b/ts/__tests__/MerkleTree.test.ts
@@ -72,23 +72,6 @@ describe('tree test', function () {
         assert.notEqual(root, wrong_calculated_root);
     });
 
-    it('tests if path consistent', async () => {
-        await tree.update(1, '6');
-        await tree.update(2, '9');
-        await tree.update(3, '8');
-        await tree.update(4, '82');
-
-        const p1 = await tree.path(2);
-
-        const index = await tree.element_index('9')
-        const p2 = await tree.path(index)
-
-        assert.strictEqual(index, 2)
-        assert.equal(typeof (index), "number")
-        assert.equal(p1.path_elements.toString(), p2.path_elements.toString());
-
-    });
-
     it('tests update log', async () => {
         const update_log_key = MerkleTree.update_log_to_key(prefix);
         const update_log_index = await tree.storage.get(update_log_key);
@@ -133,4 +116,20 @@ describe('tree test', function () {
             assert.equal(update_log_element.new_element, '6');
         }
     })
+
+    it('tests if path consistent', async () => {
+        await tree.update(1, '6');
+        await tree.update(2, '9');
+        await tree.update(3, '8');
+        await tree.update(4, '82');
+
+        const p1 = await tree.path(2);
+
+        const index = await tree.element_index('9')
+        const p2 = await tree.path(index)
+
+        assert.strictEqual(index, 2)
+        assert.equal(typeof (index), "number")
+        assert.equal(p1.path_elements.toString(), p2.path_elements.toString());
+    });
 })

--- a/ts/merkletree.ts
+++ b/ts/merkletree.ts
@@ -84,7 +84,7 @@ export default class MerkleTree {
     async element_index(element) {
         const element_key = MerkleTree.element_to_key(this.prefix, element);
         const index = await this.storage.get_or_element(element_key, -1);
-        return index;
+        return parseInt(index);
     }
 
     async path(index) {


### PR DESCRIPTION
## What's wrong

Before this fix, element_index returns a string, which causes libsemaphore to calculate wrong merkle paths, half of the time. The error propagates to the [projects](https://github.com/ChihChengLiang/semaphore_auth/issues/19) that depend on it.

## How is it fixed

Add `parseInt` in `element_index` method.

![](https://i.imgur.com/ZrrRSGe.jpg)